### PR TITLE
[libqtsparql] Fix datetime binding test. JB#57285

### DIFF
--- a/tests/auto/qsparqlbinding/tst_qsparqlbinding.cpp
+++ b/tests/auto/qsparqlbinding/tst_qsparqlbinding.cpp
@@ -225,19 +225,19 @@ void tst_QSparqlBinding::toString_data()
         QUrl("http://www.w3.org/2001/XMLSchema#time");
 
     QTest::newRow("datetime") <<
-        QVariant(QDateTime(QDate(2000, 1, 30), QTime(12, 5, 59))) <<
+        QVariant(QDateTime(QDate(2000, 1, 30), QTime(12, 5, 59), Qt::UTC)) <<
         QVariant() <<
         QVariant() <<
-        QString("\"2000-01-30T12:05:59+00:00\"") <<
+        QString("\"2000-01-30T12:05:59\"") <<
         QString("2000-01-30T12:05:59") <<
         QUrl("http://www.w3.org/2001/XMLSchema#dateTime");
 
     QTest::newRow("datetime_with_datatype") <<
-        QVariant(QDateTime(QDate(2000, 1, 30), QTime(12, 5, 59))) <<
+        QVariant(QDateTime(QDate(2000, 1, 30), QTime(12, 5, 59), Qt::UTC)) <<
         QVariant() <<
         QVariant(QUrl("http://www.w3.org/2001/XMLSchema#dateTime")) <<
-        QString("\"2000-01-30T12:05:59+00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>") <<
-        QString("2000-01-30T12:05:59") <<
+        QString("\"2000-01-30T12:05:59\"^^<http://www.w3.org/2001/XMLSchema#dateTime>") <<
+        QString("2000-01-30T12:05:59Z") <<
         QUrl("http://www.w3.org/2001/XMLSchema#dateTime");
 
     QTest::newRow("empty_string") <<


### PR DESCRIPTION
QDateTime got interpreted as local time while the result
expected UTC. Furthermore the result was expecting UTC with trailing +00:00
which QSparqlBinding::toString() explicitly omits if the offset is 0.

Likewise ISODate input on setValue() with explicit datatype got
interpreted as local time without the Z.

@Tomin1 @spiiroin 