### PR TITLE
[libqtsparql] Fix endpoint test on 64-bit. Fixes JB#57283

### DIFF
--- a/tests/auto/qsparql_endpoint/EndpointServer.cpp
+++ b/tests/auto/qsparql_endpoint/EndpointServer.cpp
@@ -64,7 +64,7 @@ void EndpointServer::stop()
     close();
 }
 
-void EndpointServer::incomingConnection(int socket)
+void EndpointServer::incomingConnection(qintptr socket)
 {
     if (disabled)
         return;

--- a/tests/auto/qsparql_endpoint/EndpointServer.h
+++ b/tests/auto/qsparql_endpoint/EndpointServer.h
@@ -55,8 +55,9 @@ public:
     void pause();
     bool resume();
     void stop();
+protected:
+    void incomingConnection(qintptr socket) override;
 private:
-    void incomingConnection(int socket);
     QString sparqlData(QString url);
 private Q_SLOTS:
     void readClient();

--- a/tests/auto/qsparql_endpoint/tst_qsparql_endpoint.cpp
+++ b/tests/auto/qsparql_endpoint/tst_qsparql_endpoint.cpp
@@ -78,7 +78,6 @@ tst_QSparqlEndpoint::~tst_QSparqlEndpoint()
 
 void tst_QSparqlEndpoint::initTestCase()
 {
-
     endpointService = new EndpointService(8080);
     endpointService->start();
     while (!endpointService->isRunning())


### PR DESCRIPTION
Wrong signature on overriden QTcpServer. Just happened to work on 32-bit
devices.

@spiiroin @Tomin1 