### PR TITLE
Fix unit test crash and adjust 'make check' tests

### DIFF
--- a/tests/auto/qsparql.pro
+++ b/tests/auto/qsparql.pro
@@ -24,10 +24,25 @@ SUBDIRS = \
 
 contains(sparql-plugins, tracker_direct): SUBDIRS += qsparql_benchmark
 
-QSPARQL_TESTS = qsparql qsparqlquery qsparqlbinding qsparql_api qsparql_tracker \
-                qsparql_tracker_direct qsparql_tracker_direct_sync qsparql_ntriples \
-                qsparql_tracker_direct_crashes \
-                qsparqlresultrow qsparql_qmlbindings qsparql_endpoint
+QSPARQL_TESTS = \
+    qsparql \
+    qsparqlquery \
+    qsparqlbinding \
+    qsparql_tracker \
+    qsparql_ntriples \
+    qsparqlresultrow \
+    qsparql_endpoint
+
+# this skipped, needs a setup where connection fails
+#     qsparql_tracker_direct_crashes \
+
+# can be enabled when qml api is back, but needs also fixing
+# qsparql_qmlbindings \
+
+# skipped due to tracker migration as above
+#    qsparql_api \
+#    qsparql_tracker_direct \
+#    qsparql_tracker_direct_sync \
 
 check.CONFIG = recursive
 check.recurse = $$QSPARQL_TESTS

--- a/tests/auto/qsparql_endpoint/EndpointServer.cpp
+++ b/tests/auto/qsparql_endpoint/EndpointServer.cpp
@@ -42,12 +42,13 @@
 #include <QTcpSocket>
 #include <QStringList>
 
-EndpointServer::EndpointServer(int _port) : port(_port), disabled(true)
+EndpointServer::EndpointServer(int _port)
+    : port(_port), disabled(true)
 {
     if (!listen(QHostAddress::Any, port)) {
-        qWarning() << "Can't bind server to port "<< port;
+        qWarning() << "Can't bind server to port " << port;
     } else {
-        disabled=false;
+        disabled = false;
         //qDebug() << "Starting fake endpoint server";
     }
 }
@@ -59,7 +60,7 @@ EndpointServer::~EndpointServer()
 
 void EndpointServer::stop()
 {
-    disabled=true;
+    disabled = true;
     //qDebug() << "Shutting down fake endpoint www server";
     close();
 }
@@ -148,9 +149,11 @@ void EndpointServer::readClient()
     // server looks if it was a get request and sends a very simple HTML
     // document back.
     QTcpSocket* socket = (QTcpSocket*)sender();
+
     if (socket->canReadLine()) {
         QStringList tokens = QString(socket->readLine()).split(QRegExp("[ \r\n][ \r\n]*"));
-        if (tokens[0] == "GET") {
+
+        if (tokens.length() >= 2 && tokens[0] == "GET") {
             QString url = tokens[1];
             QTextStream os(socket);
             os.setAutoDetectUnicode(true);
@@ -158,7 +161,7 @@ void EndpointServer::readClient()
             socket->close();
 
             if (socket->state() == QTcpSocket::UnconnectedState) {
-                delete socket;
+                socket->deleteLater();
             }
         }
     }
@@ -177,13 +180,13 @@ bool EndpointServer::isRunning() const
 
 void EndpointServer::pause()
 {
-    disabled=true;
+    disabled = true;
 }
 
 bool EndpointServer::resume()
 {
     if (isListening()) {
-        disabled=false;
+        disabled = false;
         return true;
     } else {
         //qDebug() << "Can't resume server as there was problem with binding on port " << port;

--- a/tests/auto/qsparql_endpoint/EndpointServer.h
+++ b/tests/auto/qsparql_endpoint/EndpointServer.h
@@ -51,17 +51,22 @@ class EndpointServer : public QTcpServer
 public:
     EndpointServer(int port);
     ~EndpointServer();
+
     bool isRunning() const;
     void pause();
     bool resume();
     void stop();
+
 protected:
     void incomingConnection(qintptr socket) override;
+
 private:
     QString sparqlData(QString url);
+
 private Q_SLOTS:
     void readClient();
     void discardClient();
+
 private:
     int port;
     bool disabled;

--- a/tests/auto/qsparql_endpoint/EndpointService.cpp
+++ b/tests/auto/qsparql_endpoint/EndpointService.cpp
@@ -40,7 +40,9 @@
 #include "EndpointService.h"
 #include <QDebug>
 
-EndpointService::EndpointService(int _port) : port(_port), server(0)
+EndpointService::EndpointService(int _port)
+    : port(_port)
+    , server(nullptr)
 {
 }
 

--- a/tests/auto/qsparql_endpoint/EndpointService.h
+++ b/tests/auto/qsparql_endpoint/EndpointService.h
@@ -51,11 +51,13 @@ class EndpointService : public QThread
 public:
     EndpointService(int port);
     ~EndpointService();
+
     void run();
     void stopService(int timeout);
     void pause();
     bool resume();
     bool isRunning();
+
 private:
     int port;
     EndpointServer *server;

--- a/tests/auto/qsparql_endpoint/qsparql_endpoint.pro
+++ b/tests/auto/qsparql_endpoint/qsparql_endpoint.pro
@@ -1,8 +1,10 @@
 include(../sparqltest.pri)
 CONFIG += qt warn_on console depend_includepath
 QT += testlib xml network
+
 HEADERS += EndpointService.h \
            EndpointServer.h
+
 SOURCES  += tst_qsparql_endpoint.cpp \
             EndpointService.cpp \
             EndpointServer.cpp

--- a/tests/auto/qsparql_endpoint/tst_qsparql_endpoint.cpp
+++ b/tests/auto/qsparql_endpoint/tst_qsparql_endpoint.cpp
@@ -149,7 +149,6 @@ void tst_QSparqlEndpoint::ask_query()
     delete r;
 }
 
-
 void tst_QSparqlEndpoint::query_with_error()
 {
     QSparqlConnectionOptions options;


### PR DESCRIPTION
qsparql_endpoint crashing due to deleting sender of the signal in signal handler.

